### PR TITLE
perf: use single queue instead of two

### DIFF
--- a/lib/src/main/java/com/retrozinndev/jsonutils/JSON.java
+++ b/lib/src/main/java/com/retrozinndev/jsonutils/JSON.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import com.retrozinndev.jsonutils.Message.Type;
 
 public class JSON {
-    public Map<String, Object> queuedJSONChanges = new HashMap<>();
     protected File jsonFile;
     private JSONReader jReader = null;
     private JSONBuilder jBuilder = null;
@@ -113,7 +112,7 @@ public class JSON {
      * @return This JSON instance.
      */
     public JSON newVariable(String name, Object value) {
-        queuedJSONChanges.put(name, value);
+        getBuilder().queuedJSONChanges.put(name, value);
         return this;
     }
 
@@ -126,13 +125,14 @@ public class JSON {
      * Map of String and Object, containing queued changes inside this instance.
      * 
      */
-    public Map<String, Object> getQueuedChanges() { return queuedJSONChanges; }
+    public Map<String, Object> getQueuedChanges() { return getBuilder().queuedJSONChanges; }
     /**
      * Reads the JSON file. Can be used to prevent problems when trying to get a recently added value to JSON.
      * @return A JSONReader instance.
      */
     public JSON read() {
         getReader().readMap(this);
+        getBuilder().getMap().putAll(this.toMap());
         return this;
     }
 
@@ -141,7 +141,7 @@ public class JSON {
      * @return this JSON instance.
      */
     public JSON write() {
-        getBuilder().writeJSON(this); 
+        getBuilder().writeJSON(toFile());
         read();
         return this;
     }

--- a/lib/src/main/java/com/retrozinndev/jsonutils/JSONBuilder.java
+++ b/lib/src/main/java/com/retrozinndev/jsonutils/JSONBuilder.java
@@ -12,9 +12,7 @@ import com.retrozinndev.jsonutils.Message.Type;
 public class JSONBuilder {
     public Map<String, Object> jsonMap = new HashMap<>();
     public Map<String, Object> queuedJSONChanges = new HashMap<>();
-    private boolean onlyBuildMode = true;
     private File jsonFile;
-    private JSON jsonInst;
     public String tab = "    ";
 
     /**
@@ -61,11 +59,10 @@ public class JSONBuilder {
      * @param json The JSON instance you want to use.
      */
     public JSONBuilder(JSON json) {
-        this.onlyBuildMode = false;
         if(!json.jsonFile.toString().endsWith(".json")) {
             json.jsonFile = new File(json.jsonFile.toString()+".json");
         }
-        this.jsonInst = json;
+        this.jsonFile = json.toFile();
     }
 
     /**
@@ -111,21 +108,21 @@ public class JSONBuilder {
      * @return
      * The JSON instance.
      */
-    public JSON writeJSON(JSON json) {
-        json.toMap().putAll(json.getQueuedChanges());
+    public File writeJSON(File outputFile) {
+        getMap().putAll(getQueuedChanges());
         queuedJSONChanges.clear();
         BufferedWriter writer;
         try {
-            writer = new BufferedWriter(new FileWriter(json.toFile()));
+            writer = new BufferedWriter(new FileWriter(outputFile));
             writer.write("{\n");
-            for(int i = 0; i < json.toMap().keySet().size(); i++) {
-                String lineKey = json.toMap().keySet().toArray()[i].toString();
-                Object lineValue = json.toMap().get(lineKey);
+            for(int i = 0; i < getMap().keySet().size(); i++) {
+                String lineKey = getMap().keySet().toArray()[i].toString();
+                Object lineValue = getMap().get(lineKey);
                 String jsonLine = "\""+lineKey+"\": "+lineValue;
                 if(lineValue instanceof String) 
                     jsonLine = "\""+lineKey+"\": \""+lineValue.toString()+"\"";
 
-                if(i != json.toMap().size() - 1) { jsonLine+=", \n"; }
+                if(i != getMap().size() - 1) { jsonLine+=", \n"; }
                 writer.write(tab+jsonLine);
             }
 
@@ -133,7 +130,7 @@ public class JSONBuilder {
             writer.close();
         } catch(IOException e) { e.printStackTrace(); }
 
-        return json;
+        return outputFile;
     }
 
     /**
@@ -155,16 +152,6 @@ public class JSONBuilder {
         return jsonFile;
     }
 
-    private boolean isBuildOnly() {
-        if(onlyBuildMode) {
-            Message.send(Type.Error, "Can't write modifications: You're using JSONBuilder Only Build mode.");
-            Message.send(Type.Tip, "Use a JSON instance instead of File/String to disable it.");
-            return true;
-        }
-
-        return false;
-    }
-
     /**
      * Writes the final JSON with the given objects in the JSON directory.
      * @return
@@ -173,17 +160,12 @@ public class JSONBuilder {
     public JSON makeJSON() {
         if(!jsonFile.exists()) { makeEmptyJSON(jsonFile); }
         boolean hasModifications = queuedJSONChanges.size() > 0;
-        if(hasModifications) { 
-            if(onlyBuildMode) {
-                writeFile();
-            } else if(!isBuildOnly()) {
-                writeJSON(jsonInst); 
-            }
-        }
+        if(hasModifications) 
+            writeJSON(jsonFile);
         else 
             Message.send(Type.Alert, "No modifications were found for the json object. Skipping write.");
         
-        return new JSON(jsonFile);
+        return null;
     }
 
     public JSONBuilder newVariable(String keyString, boolean value) {


### PR DESCRIPTION
This commit makes [JSON class](https://github.com/retrozinndev/JSONutils/wiki/Documentation#JSONBuilder)' queue obsolete, and makes usage of a single Hash Map queue of the [JSONBuilder class](https://github.com/retrozinndev/JSONutils/wiki/Documentation#JSONBuilder). Removes the extra function to build the output JSON file called `writeFile()` and change the `writeJSON(File)` as the main method to write JSONs.